### PR TITLE
WIP: Add metroConfig path option

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -258,11 +258,12 @@ function startServerInNewWindow(
    * Set up the `.packager.(env|bat)` file to ensure the packager starts on the right port.
    */
   const metroConfigPath = path.resolve(metroConfig);
+  const metroConfigOption = `--config ${metroConfigPath}`
   const launchPackagerPath = path.join(
     reactNativePath,
     `scripts/${scriptFile}`,
   );
-  const launchPackagerScript = launchPackagerPath.concat(metroConfigPath);
+  const launchPackagerScript = launchPackagerPath.concat(metroConfigOption);
 
   /**
    * Set up the `launchpackager.(command|bat)` file.

--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -51,6 +51,7 @@ export interface Flags {
   port: number;
   terminal: string;
   jetifier: boolean;
+  metroConfig: string;
 }
 
 type AndroidProject = NonNullable<Config['project']['android']>;
@@ -95,6 +96,7 @@ async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
           args.port,
           args.terminal,
           config.reactNativePath,
+          args.metroConfig,
         );
       } catch (error) {
         logger.warn(
@@ -238,6 +240,7 @@ function startServerInNewWindow(
   port: number,
   terminal: string,
   reactNativePath: string,
+  metroConfig: string,
 ) {
   /**
    * Set up OS-specific filenames and commands
@@ -254,10 +257,12 @@ function startServerInNewWindow(
   /**
    * Set up the `.packager.(env|bat)` file to ensure the packager starts on the right port.
    */
-  const launchPackagerScript = path.join(
+  const metroConfigPath = path.resolve(metroConfig);
+  const launchPackagerPath = path.join(
     reactNativePath,
     `scripts/${scriptFile}`,
   );
+  const launchPackagerScript = launchPackagerPath.concat(metroConfigPath);
 
   /**
    * Set up the `launchpackager.(command|bat)` file.
@@ -379,6 +384,12 @@ export default {
       name: '--no-jetifier',
       description:
         'Do not run "jetifier" – the AndroidX transition tool. By default it runs before Gradle to ease working with libraries that don\'t support AndroidX yet. See more at: https://www.npmjs.com/package/jetifier.',
+    },
+    {
+      name: '--metroConfig <string>',
+      description:
+        'Specify a custom Metro config path.',
+      default: '',
     },
   ],
 };


### PR DESCRIPTION
Summary:
---------

Started to work on adding metro config option instead of launchPackagerPath per discussion here: https://github.com/react-native-community/cli/pull/1358

Unfortunately, it still uses root config when running Android, so I might need help to figure out where the option should be passed. 